### PR TITLE
[feature] Create POST /documents endpoint with unique slug generation (#2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  test:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 24
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npm run lint
 npm run format
+npm run test

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    },
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
   }

--- a/src/__tests__/document.service.spec.ts
+++ b/src/__tests__/document.service.spec.ts
@@ -1,0 +1,123 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { nanoid } from 'nanoid';
+import { QueryFailedError, Repository } from 'typeorm';
+import { DocumentService } from '@/document/document.service';
+import { CreateDocumentDto } from '@/document/dto/create-document.dto';
+import { DocumentEntity } from '@/document/entities/document.entity';
+
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(),
+}));
+
+describe('DocumentService', () => {
+  let service: DocumentService;
+  let repo: Partial<Record<keyof Repository<DocumentEntity>, jest.Mock>>;
+  let configService: Partial<ConfigService>;
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    configService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === 'APP_HOST') return 'localhost:4200';
+        return undefined;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentService,
+        {
+          provide: getRepositoryToken(DocumentEntity),
+          useValue: repo,
+        },
+        {
+          provide: ConfigService,
+          useValue: configService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DocumentService>(DocumentService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('успешное создание документа — возвращается корректная sharedLink', async () => {
+    const dto: CreateDocumentDto = {
+      title: 'title',
+      markdown: 'document',
+    } as any;
+
+    const mockedNanoid = nanoid as jest.Mock;
+    mockedNanoid.mockReturnValueOnce('3j4ejedf');
+
+    (repo.create as jest.Mock).mockImplementation((data) => ({
+      id: 1,
+      ...data,
+    }));
+
+    (repo.save as jest.Mock).mockImplementation(async (entity) => ({
+      ...entity,
+    }));
+
+    const result = await service.create(dto);
+
+    expect(repo.create).toHaveBeenCalledTimes(1);
+    expect(repo.create).toHaveBeenCalledWith({ ...dto, slug: '3j4ejedf' });
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      sharedLink: 'https://localhost:4200/doc/3j4ejedf',
+    });
+  });
+
+  it('если первый сгенерированный slug конфликтует (код 23505), сервис повторяет и возвращает ссылку с новым slug', async () => {
+    const dto: CreateDocumentDto = {
+      title: 'title',
+      markdown: 'document',
+    };
+    const mockedNanoid = nanoid as jest.Mock;
+    mockedNanoid
+      .mockReturnValueOnce('conflict1')
+      .mockReturnValueOnce('okslug2');
+
+    (repo.create as jest.Mock).mockImplementation((data) => ({ ...data }));
+
+    const firstError = new QueryFailedError(
+      'INSERT ...',
+      [],
+      new Error('Non-unique slug'),
+    );
+    (firstError as any).code = '23505';
+
+    (repo.save as jest.Mock)
+      .mockImplementationOnce(async () => {
+        throw firstError;
+      })
+      .mockImplementationOnce(async (entity) => ({ ...entity }));
+
+    const result = await service.create(dto);
+
+    expect(mockedNanoid).toHaveBeenCalledTimes(2);
+    expect(repo.create).toHaveBeenCalledTimes(2);
+    expect(repo.create).toHaveBeenNthCalledWith(1, {
+      ...dto,
+      slug: 'conflict1',
+    });
+    expect(repo.create).toHaveBeenNthCalledWith(2, { ...dto, slug: 'okslug2' });
+
+    expect(repo.save).toHaveBeenCalledTimes(2);
+
+    expect(result).toEqual({
+      sharedLink: 'https://localhost:4200/doc/okslug2',
+    });
+  });
+});

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { DocumentModule } from './document/document.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
         synchronize: config.getOrThrow('NODE_ENV') !== 'production',
       }),
     }),
+    DocumentModule,
   ],
   controllers: [],
   providers: [],

--- a/src/document/document.controller.ts
+++ b/src/document/document.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { DocumentService } from './document.service';
+
+@Controller('documents')
+export class DocumentController {
+  constructor(private readonly _documentService: DocumentService) {}
+}

--- a/src/document/document.controller.ts
+++ b/src/document/document.controller.ts
@@ -6,9 +6,20 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { DocumentService } from './document.service';
 import { CreateDocumentDto } from './dto/create-document.dto';
+import {
+  DocumentBadRequestResponse,
+  DocumentOkResponse,
+} from './swagger/response.types';
 
+@ApiTags('Документы')
 @Controller('documents')
 export class DocumentController {
   public constructor(private readonly _documentService: DocumentService) {}
@@ -16,6 +27,16 @@ export class DocumentController {
   @Post()
   @HttpCode(201)
   @UsePipes(new ValidationPipe())
+  @ApiOperation({ summary: 'Создание короткой ссылки на markdown' })
+  @ApiOkResponse({
+    type: DocumentOkResponse,
+    description: 'Короткая ссылка на переданный markdown успешно создана',
+  })
+  @ApiBadRequestResponse({
+    type: DocumentBadRequestResponse,
+    description:
+      'Данные для создания короткой ссылки на markdown были переданы неверно',
+  })
   public async create(@Body() dto: CreateDocumentDto) {
     return this._documentService.create(dto);
   }

--- a/src/document/document.controller.ts
+++ b/src/document/document.controller.ts
@@ -1,7 +1,22 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { DocumentService } from './document.service';
+import { CreateDocumentDto } from './dto/create-document.dto';
 
 @Controller('documents')
 export class DocumentController {
-  constructor(private readonly _documentService: DocumentService) {}
+  public constructor(private readonly _documentService: DocumentService) {}
+
+  @Post()
+  @HttpCode(201)
+  @UsePipes(new ValidationPipe())
+  public async create(@Body() dto: CreateDocumentDto) {
+    return this._documentService.create(dto);
+  }
 }

--- a/src/document/document.module.ts
+++ b/src/document/document.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DocumentController } from './document.controller';
 import { DocumentService } from './document.service';
 import { DocumentEntity } from './entities/document.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DocumentEntity])],
+  imports: [TypeOrmModule.forFeature([DocumentEntity]), ConfigModule],
   controllers: [DocumentController],
   providers: [DocumentService],
 })

--- a/src/document/document.module.ts
+++ b/src/document/document.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DocumentController } from './document.controller';
+import { DocumentService } from './document.service';
+import { DocumentEntity } from './entities/document.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DocumentEntity])],
+  controllers: [DocumentController],
+  providers: [DocumentService],
+})
+export class DocumentModule {}

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DocumentService {}

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -1,4 +1,43 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { nanoid } from 'nanoid';
+import { QueryFailedError, Repository } from 'typeorm';
+import { CreateDocumentDto } from './dto/create-document.dto';
+import { DocumentEntity } from './entities/document.entity';
 
 @Injectable()
-export class DocumentService {}
+export class DocumentService {
+  private static readonly SLUG_LENGTH = 8;
+  private static readonly NON_UNIQUE_ERROR_CODE = '23505';
+
+  public constructor(
+    @InjectRepository(DocumentEntity)
+    private readonly _documentRepository: Repository<DocumentEntity>,
+  ) {}
+
+  public async create(dto: CreateDocumentDto): Promise<DocumentEntity> {
+    while (true) {
+      const slug = nanoid(DocumentService.SLUG_LENGTH);
+
+      const document = this._documentRepository.create({
+        ...dto,
+        slug,
+      });
+
+      try {
+        return this._documentRepository.save(document);
+      } catch (error) {
+        if (this._isNonUniqueSlugGenerated(error)) continue;
+        throw error;
+      }
+    }
+  }
+
+  private _isNonUniqueSlugGenerated(error: any) {
+    return (
+      error instanceof QueryFailedError &&
+      (error as QueryFailedError & { code: string }).code ===
+        DocumentService.NON_UNIQUE_ERROR_CODE
+    );
+  }
+}

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { nanoid } from 'nanoid';
 import { QueryFailedError, Repository } from 'typeorm';
@@ -13,9 +14,10 @@ export class DocumentService {
   public constructor(
     @InjectRepository(DocumentEntity)
     private readonly _documentRepository: Repository<DocumentEntity>,
+    private readonly _configService: ConfigService,
   ) {}
 
-  public async create(dto: CreateDocumentDto): Promise<DocumentEntity> {
+  public async create(dto: CreateDocumentDto): Promise<{ sharedLink: string }> {
     while (true) {
       const slug = nanoid(DocumentService.SLUG_LENGTH);
 
@@ -25,11 +27,15 @@ export class DocumentService {
       });
 
       try {
-        return this._documentRepository.save(document);
+        await this._documentRepository.save(document);
       } catch (error) {
         if (this._isNonUniqueSlugGenerated(error)) continue;
         throw error;
       }
+
+      const sharedLink = this._makeSharedLinkBySlug(slug);
+
+      return { sharedLink };
     }
   }
 
@@ -39,5 +45,11 @@ export class DocumentService {
       (error as QueryFailedError & { code: string }).code ===
         DocumentService.NON_UNIQUE_ERROR_CODE
     );
+  }
+
+  private _makeSharedLinkBySlug(slug: string): string {
+    const host = this._configService.get<string>('APP_HOST');
+
+    return `https://${host}/doc/${slug}`;
   }
 }

--- a/src/document/dto/create-document.dto.ts
+++ b/src/document/dto/create-document.dto.ts
@@ -1,11 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class CreateDocumentDto {
+  @ApiProperty({
+    required: true,
+    example: 'README',
+    description: 'Название',
+  })
   @IsString({ message: 'Название должно быть строкой.' })
   @IsNotEmpty({ message: 'Название не должно быть пустым.' })
   @MaxLength(255, { message: 'Название слишком длинное.' })
   title: string;
 
+  @ApiProperty({
+    required: true,
+    example: '## Hello, world!',
+    description: 'Текст в формате markdown',
+  })
   @IsString({ message: 'Markdown должен быть строкой.' })
   @IsNotEmpty({ message: 'Markdown не должен быть пустым.' })
   markdown: string;

--- a/src/document/dto/create-document.dto.ts
+++ b/src/document/dto/create-document.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateDocumentDto {
+  @IsString({ message: 'Название должно быть строкой.' })
+  @IsNotEmpty({ message: 'Название не должно быть пустым.' })
+  @MaxLength(255, { message: 'Название слишком длинное.' })
+  title: string;
+
+  @IsString({ message: 'Markdown должен быть строкой.' })
+  @IsNotEmpty({ message: 'Markdown не должен быть пустым.' })
+  markdown: string;
+}

--- a/src/document/entities/document.entity.ts
+++ b/src/document/entities/document.entity.ts
@@ -1,0 +1,24 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity({ name: 'documents' })
+export class DocumentEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column()
+  markdown: string;
+
+  @Column({ unique: true })
+  slug: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/src/document/swagger/response.types.ts
+++ b/src/document/swagger/response.types.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DocumentOkResponse {
+  @ApiProperty({
+    required: true,
+    example: 'https://md.evdmatvey.ru/doc/843jdea3',
+    description:
+      'Короткая ссылка, которая ведёт на загруженный пользователем markdown',
+  })
+  sharedLink: string;
+}
+
+export class DocumentBadRequestResponse {
+  @ApiProperty({
+    required: true,
+    example: ['Название не должно быть пустым.'],
+    description:
+      'Сообщения, уточняющие какие именно данные были переданы неверно',
+  })
+  message: string[];
+
+  @ApiProperty({
+    required: true,
+    example: 'Bad Request',
+    description: 'Тип HTTP ошибки в строковом виде',
+  })
+  error: string;
+
+  @ApiProperty({
+    required: true,
+    example: 400,
+    description: 'Тип HTTP ошибки в виде кода',
+  })
+  statusCode: number;
+}


### PR DESCRIPTION
## Goal
Implement the `POST /documents` endpoint along with the full document-creation flow: entity, module, service, slug generation, and database persistence.

Related Issue: #2

Closes #2

## Changes
- Added `DocumentModule` with controller, service и entity  
- Implemented `DocumentEntity` TypeORM entity:
  - `id` (UUID)
  - `title`
  - `markdown`
  - `slug` (unique)
  - `createdAt`
- Added slug generation via `nanoid` (8 chars) with retry on unique constraint conflicts
- Implemented `DocumentService.create()` with full persistence logic
- Created `POST /documents` endpoint with DTO validation
- Integrated module into main application structure
- Added minimal unit tests for document creation logic (where applicable)

## Type of Change
- [ ] Fix  
- [x] Feature  
- [ ] Refactor  
- [ ] Enhancement  
- [ ] Breaking change  
- [ ] Chore  
- [ ] Test  
- [ ] Docs  

## Checklist
- [x] Matches the description in the related Issue  
- [x] Code formatted (lint/format)  
- [x] Locally tested  
- [ ] CI passed  
- [x] No unnecessary commits (will be squashed)  

## Notes
The new endpoint enables document creation and returns a ready-to-use sharing URL. Slug collisions are handled automatically through regeneration, ensuring consistent behavior even under high load.
