### PR TITLE
[feature] Get document by slug (#3)

### DIFF
--- a/src/__tests__/document.service.spec.ts
+++ b/src/__tests__/document.service.spec.ts
@@ -20,6 +20,7 @@ describe('DocumentService', () => {
     repo = {
       create: jest.fn(),
       save: jest.fn(),
+      findOne: jest.fn(),
     };
 
     configService = {
@@ -119,5 +120,29 @@ describe('DocumentService', () => {
     expect(result).toEqual({
       sharedLink: 'https://localhost:4200/doc/okslug2',
     });
+  });
+
+  it('Get document by slug', async () => {
+    const slug = '4ud9qwkd';
+
+    (repo.findOne as jest.Mock).mockImplementation(({ where: { slug } }) => ({
+      slug,
+    }));
+
+    const result = await service.getBySlug(slug);
+
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { slug } });
+    expect(result.slug).toBe(slug);
+  });
+
+  it('Get NotFoundException while getting document by incorrect slug', async () => {
+    const slug = '4ud9qwkd';
+
+    (repo.findOne as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.getBySlug(slug)).rejects.toThrow(
+      `Документ по slug "${slug}" не найден.`,
+    );
+    expect(repo.findOne).toHaveBeenCalledWith({ where: { slug } });
   });
 });

--- a/src/__tests__/document.service.spec.ts
+++ b/src/__tests__/document.service.spec.ts
@@ -50,7 +50,7 @@ describe('DocumentService', () => {
     jest.clearAllMocks();
   });
 
-  it('успешное создание документа — возвращается корректная sharedLink', async () => {
+  it('Create document and return valid sharedLink', async () => {
     const dto: CreateDocumentDto = {
       title: 'title',
       markdown: 'document',
@@ -79,7 +79,7 @@ describe('DocumentService', () => {
     });
   });
 
-  it('если первый сгенерированный slug конфликтует (код 23505), сервис повторяет и возвращает ссылку с новым slug', async () => {
+  it('Retry slug generation on conflict and return new slug', async () => {
     const dto: CreateDocumentDto = {
       title: 'title',
       markdown: 'document',

--- a/src/document/document.controller.ts
+++ b/src/document/document.controller.ts
@@ -1,13 +1,16 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
+  Param,
   Post,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -15,8 +18,10 @@ import {
 import { DocumentService } from './document.service';
 import { CreateDocumentDto } from './dto/create-document.dto';
 import {
+  CreateDocumentOkResponse,
   DocumentBadRequestResponse,
-  DocumentOkResponse,
+  DocumentNotFoundResponse,
+  GetDocumentOkResponse,
 } from './swagger/response.types';
 
 @ApiTags('Документы')
@@ -29,7 +34,7 @@ export class DocumentController {
   @UsePipes(new ValidationPipe())
   @ApiOperation({ summary: 'Создание короткой ссылки на markdown' })
   @ApiOkResponse({
-    type: DocumentOkResponse,
+    type: CreateDocumentOkResponse,
     description: 'Короткая ссылка на переданный markdown успешно создана',
   })
   @ApiBadRequestResponse({
@@ -39,5 +44,21 @@ export class DocumentController {
   })
   public async create(@Body() dto: CreateDocumentDto) {
     return this._documentService.create(dto);
+  }
+
+  @Get(':slug')
+  @ApiOperation({ summary: 'Получение markdown документа по его slug' })
+  @ApiOkResponse({
+    type: GetDocumentOkResponse,
+    description: 'Документ успешно получен по переданному slug',
+  })
+  @ApiNotFoundResponse({
+    type: DocumentNotFoundResponse,
+    description: 'По переданному slug документ не найден',
+  })
+  public async getBySlug(@Param('slug') slug: string) {
+    const document = await this._documentService.getBySlug(slug);
+
+    return { document };
   }
 }

--- a/src/document/document.service.ts
+++ b/src/document/document.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { nanoid } from 'nanoid';
@@ -16,6 +16,19 @@ export class DocumentService {
     private readonly _documentRepository: Repository<DocumentEntity>,
     private readonly _configService: ConfigService,
   ) {}
+
+  public async getBySlug(slug: string): Promise<DocumentEntity> {
+    const document = await this._documentRepository.findOne({
+      where: {
+        slug,
+      },
+    });
+
+    if (!document)
+      throw new NotFoundException(`Документ по slug \"${slug}\" не найден.`);
+
+    return document;
+  }
 
   public async create(dto: CreateDocumentDto): Promise<{ sharedLink: string }> {
     while (true) {

--- a/src/document/swagger/response.types.ts
+++ b/src/document/swagger/response.types.ts
@@ -1,6 +1,43 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class DocumentOkResponse {
+export class DocumentEntityResponse {
+  @ApiProperty({
+    required: true,
+    example: 'dcc3dcf2-11a5-46d4-9644-742a95aad2b3',
+    description: 'Идентификатор документа',
+  })
+  id: string;
+
+  @ApiProperty({
+    required: true,
+    example: 'Title',
+    description: 'Название документа',
+  })
+  title: string;
+
+  @ApiProperty({
+    required: true,
+    example: '## Markdown code',
+    description: 'Текст в формате markdown',
+  })
+  markdown: string;
+
+  @ApiProperty({
+    required: true,
+    example: '843jdea3',
+    description: 'Короткий идентификатор документа',
+  })
+  slug: string;
+
+  @ApiProperty({
+    required: true,
+    example: '2025-11-25T06:00:36.138Z',
+    description: 'Дата создания в ISO формате',
+  })
+  createdAt: string;
+}
+
+export class CreateDocumentOkResponse {
   @ApiProperty({
     required: true,
     example: 'https://md.evdmatvey.ru/doc/843jdea3',
@@ -8,6 +45,15 @@ export class DocumentOkResponse {
       'Короткая ссылка, которая ведёт на загруженный пользователем markdown',
   })
   sharedLink: string;
+}
+
+export class GetDocumentOkResponse {
+  @ApiProperty({
+    required: true,
+    type: DocumentEntityResponse,
+    description: 'Markdown документ',
+  })
+  document: string;
 }
 
 export class DocumentBadRequestResponse {
@@ -29,6 +75,29 @@ export class DocumentBadRequestResponse {
   @ApiProperty({
     required: true,
     example: 400,
+    description: 'Тип HTTP ошибки в виде кода',
+  })
+  statusCode: number;
+}
+
+export class DocumentNotFoundResponse {
+  @ApiProperty({
+    required: true,
+    example: 'Документ по slug \"843jdea3\" не найден.',
+    description: 'Сообщения, уточняющие почему не был найден документ',
+  })
+  message: string[];
+
+  @ApiProperty({
+    required: true,
+    example: 'Not Found',
+    description: 'Тип HTTP ошибки в строковом виде',
+  })
+  error: string;
+
+  @ApiProperty({
+    required: true,
+    example: 404,
     description: 'Тип HTTP ошибки в виде кода',
   })
   statusCode: number;


### PR DESCRIPTION
## Goal
Implement the `GET /documents/:slug` endpoint that retrieves a document by its unique slug and returns its details in JSON format.

Related Issue: #3

Closes #3

## Changes
- Added `getBySlug(slug: string)` method to `DocumentService`
  - Fetches document via TypeORM repository  
  - Throws `NotFoundException` when slug does not exist
- Added `GET /documents/:slug` endpoint to `DocumentController`
  - Accepts slug as a route param  
  - Returns document data in JSON format
- Updated `DocumentModule` to expose new route
- Added unit tests:
  - Returns correct document when slug exists  
  - Throws `NotFoundException` for missing document
- Ensured integration with database through repository injection

## Type of Change
- [ ] Fix  
- [x] Feature  
- [ ] Refactor  
- [ ] Enhancement  
- [ ] Breaking change  
- [ ] Chore  
- [ ] Test  
- [ ] Docs  

## Checklist
- [x] Matches the description in the related Issue  
- [x] Code formatted (lint/format)  
- [x] Locally tested  
- [ ] CI passed  
- [x] No unnecessary commits (will be squashed)  

## Notes
This endpoint enables users to open shared document links and view their contents, completing the read part of the document-sharing flow.
